### PR TITLE
Removed query string from nodeActive comparison

### DIFF
--- a/services/NaveeService.php
+++ b/services/NaveeService.php
@@ -147,7 +147,7 @@ class NaveeService extends BaseApplicationComponent {
   private function nodeActive(Navee_NodeModel $node)
   {
     $data       = false;
-    $currentUri = ltrim(craft()->request->getRequestUri(), '/');
+    $currentUri = ltrim(craft()->request->getPath(), '/');
     $link       = ltrim($node->link, '/');
 
     if (($link == $currentUri) && !$node->passive)


### PR DESCRIPTION
Switched from getRequestUri(), which includes the query string, to getPath(), which does not. This avoids the activeNode check failing when a query string is included in the URL.
